### PR TITLE
Get last cache entry when matching on restore keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ function getMatchingPrimaryKey(primaryKey, version, restorePaths=[], exactMatch 
     }
     else
     {
-        row = db.prepare(`SELECT * FROM caches WHERE key LIKE '${primaryKey}%' AND version = '${version}'`).get();
+        row = db.prepare(`SELECT * FROM caches WHERE key LIKE '${primaryKey}%' AND version = '${version}' ORDER BY id DESC`).get();
     }
     if(row !== undefined)
     {

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ server.get('/', (req, res) => {
 
 function getMatchingPrimaryKey(primaryKey, version, restorePaths=[], exactMatch = true) {
     let row;
-    if(exactMatch === false)
+    if(exactMatch)
     {
         row = db.prepare("SELECT * FROM caches WHERE key = ? AND version = ?").get(primaryKey, version);
     }


### PR DESCRIPTION
Based on the official [documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-multiple-restore-keys) when there are multiple match with a restore key;

> The restore key `npm-feature-` matches any key that starts with the string `npm-feature-`. For example, both of the keys `npm-feature-fd3052de` and `npm-feature-a9b253ff` match the restore key. **The cache with the most recent creation date would be used**. 

I updated the restore keys SQL request to sort the matching rows by descending id value. So the first row would be the newest.

Also, thanks guys for your work. It is such a time saver!